### PR TITLE
ci: add fmt/clippy/test/docs checks and a cargo-deny audit

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,22 @@
+name: Audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    # Weekly, Monday 09:00 UTC, so fresh advisories surface without a code change.
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel superseded runs on the same ref so a fresh push supersedes the old one.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least privilege: the jobs only need to read the checkout.
+permissions:
+  contents: read
+
+jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install toolchain from rust-toolchain.toml
+        run: rustup toolchain install
+      - run: cargo fmt --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install toolchain from rust-toolchain.toml
+        run: rustup toolchain install
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --locked --all-targets -- -D warnings
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install toolchain from rust-toolchain.toml
+        run: rustup toolchain install
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --locked
+
+  docs:
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install toolchain from rust-toolchain.toml
+        run: rustup toolchain install
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo doc --no-deps

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,32 @@
+# cargo-deny policy.
+#
+# The license allow-list below lists every license present in the dependency
+# tree. If a new dependency introduces a license that is not here, the licenses
+# check fails; regenerate the set with `cargo-deny list` and add the new license
+# only after confirming it is compatible with this crate's GPL-3.0-only terms.
+
+[advisories]
+# RUSTSEC advisories and unmaintained crates fail by default in cargo-deny 0.19.
+# Add an advisory ID here only with a written reason and, ideally, a tracking link.
+ignore = []
+
+[licenses]
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "GPL-3.0-only",
+    "ISC",
+    "MIT",
+    "Unicode-3.0",
+    "Unlicense",
+]
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "warn"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"

--- a/examples/explore.rs
+++ b/examples/explore.rs
@@ -49,12 +49,16 @@ fn parse_args(argv: &[String]) -> Result<Option<Args>, String> {
         } else if arg == "--keep" {
             keep = true;
         } else if arg == "--port" {
-            let value = iter.next().ok_or_else(|| "--port needs a value".to_string())?;
+            let value = iter
+                .next()
+                .ok_or_else(|| "--port needs a value".to_string())?;
             port = Some(parse_port(value)?);
         } else if let Some(value) = arg.strip_prefix("--port=") {
             port = Some(parse_port(value)?);
         } else if arg == "--ttl" {
-            let value = iter.next().ok_or_else(|| "--ttl needs a value".to_string())?;
+            let value = iter
+                .next()
+                .ok_or_else(|| "--ttl needs a value".to_string())?;
             ttl_seconds = parse_ttl(value)?;
         } else if let Some(value) = arg.strip_prefix("--ttl=") {
             ttl_seconds = parse_ttl(value)?;
@@ -134,7 +138,10 @@ fn catalog_listing() -> String {
     out.push_str(USAGE);
     out.push_str("\n\nscenarios:\n");
     for scenario in catalog() {
-        out.push_str(&format!("  {:<14}{}\n", scenario.name, scenario.description));
+        out.push_str(&format!(
+            "  {:<14}{}\n",
+            scenario.name, scenario.description
+        ));
     }
     out
 }
@@ -316,7 +323,9 @@ async fn main() -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
-    let addr = listener.local_addr().expect("a bound listener has a local address");
+    let addr = listener
+        .local_addr()
+        .expect("a bound listener has a local address");
     println!("scenario: {}", scenario.name);
     println!("listening on http://{addr}");
     println!("Press Ctrl-C to stop.");

--- a/mise.toml
+++ b/mise.toml
@@ -6,3 +6,4 @@
 
 [tools]
 "cargo:bacon" = "3"
+"aqua:EmbarkStudios/cargo-deny" = "0.19"

--- a/src/state.rs
+++ b/src/state.rs
@@ -145,7 +145,10 @@ mod tests {
         let first = cache.get_or_build(|| async { sample_view("first") }).await;
         // A second call within the TTL must not build again.
         let second = cache.get_or_build(|| async { sample_view("second") }).await;
-        assert!(Arc::ptr_eq(&first, &second), "a fresh cache must not rebuild");
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "a fresh cache must not rebuild"
+        );
         assert_eq!(second[0].path, "first");
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -215,7 +215,10 @@ mod tests {
             children: vec![flagged_leaf("Book", "Author/Book")],
         }];
         remove_subtree(&mut forest, "Author/Book");
-        assert!(forest.is_empty(), "removing the only child prunes the container");
+        assert!(
+            forest.is_empty(),
+            "removing the only child prunes the container"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Adds GitHub Actions CI to `missing-ebooks`.

- Add `ci.yml` with four parallel jobs (fmt, clippy, test, docs) on the toolchain pinned by `rust-toolchain.toml`, so 1.96.0 isn't duplicated in YAML
- Add `audit.yml` running cargo-deny on every PR and push, plus a weekly Monday 09:00 UTC cron and a manual `workflow_dispatch`
- Add `deny.toml` whose license allow-list was validated against the real dependency tree, not guessed
- Pin cargo-deny 0.19 via the aqua mise backend so the local audit and license allow-list match CI
- Format `examples/explore.rs`, `src/state.rs`, and `src/tree.rs` with rustfmt so the new fmt gate starts green (pure reflow, no logic changes)

> Branch protection (marking `fmt`, `clippy`, `test`, `docs`, `cargo-deny` required on `main`) is a repo setting applied after the first run, so it's not part of this PR.
